### PR TITLE
Add Back to Top button at bottom of README for easier navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,11 @@ Ensure you have the following installed:
 git clone [https://github.com/your-username/SkillHub-CourseSelling.git](https://github.com/your-username/SkillHub-CourseSelling.git)
 cd SkillHub-CourseSelling
 
+```
+
+
+<p align="center">
+  <a href="#top" style="font-size: 16px; padding: 8px 16px; border: 1px solid #ccc; border-radius: 6px; text-decoration: none;">
+    ⬆️ Back to Top
+  </a>
+</p>


### PR DESCRIPTION
This PR improves the readability and navigation of the README.md file by adding a Back to Top button at the bottom. This eliminates the need for manual scrolling, especially in long documentation.

Changes Made

Added a center-aligned Back to Top button at the end of the README.md file.

Issue number #54 